### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,4 +1,6 @@
 name: PHPStan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-assets/security/code-scanning/2](https://github.com/RumenDamyanov/php-assets/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and run analysis, it only requires read access to repository contents. The best way to do this is to add the following at the top level of the workflow file (after the `name` key and before `on`):  
```yaml
permissions:
  contents: read
```
This ensures that all jobs in the workflow inherit these minimal permissions unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
