### PR TITLE
Merge develop to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,16 @@ permissions:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
       - name: Set up PHP

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,16 +4,16 @@ permissions:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   phpstan:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -6,15 +6,28 @@
     "authors": [
         {
             "name": "Rumen Damyanov",
-            "email": "contact@rumenx.com"
+            "email": "contact@rumenx.com",
+            "role": "Developer",
+            "homepage": "https://rumenx.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/RumenDamyanov/php-assets/issues",
+        "source": "https://github.com/RumenDamyanov/php-assets",
+        "wiki": "https://github.com/RumenDamyanov/php-assets/wiki"
+    },
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/RumenDamyanov"
         }
     ],
     "require": {
-        "php": ">=8.3"
+        "php": "^8.2"
     },
     "require-dev": {
-        "pestphp/pest": "^4.0",
-        "phpstan/phpstan": "^2.1"
+        "pestphp/pest": "^2.0 || ^3.0 || ^4.0",
+        "phpstan/phpstan": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request updates configuration files and metadata to improve compatibility and project documentation. The main changes expand CI workflow coverage to include the `develop` branch and PHP 8.2, and enhance the project's `composer.json` with additional author information, support links, and funding options.

**CI Workflow Improvements:**
* Updated `.github/workflows/ci.yml` and `.github/workflows/phpstan.yml` to run on both `master` and `develop` branches, and to test against PHP versions 8.2, 8.3, and 8.4. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL8-R17) [[2]](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546L7-R16)

**Composer Metadata Enhancements:**
* Added `role` and `homepage` fields to the author entry in `composer.json`, and introduced `support` and `funding` sections for better documentation and sponsorship visibility.
* Broadened PHP version requirement to `^8.2` and relaxed version constraints for development dependencies (`pestphp/pest` and `phpstan/phpstan`) to support a wider range of versions.